### PR TITLE
RTR support

### DIFF
--- a/FlexCAN.h
+++ b/FlexCAN.h
@@ -11,6 +11,7 @@
 typedef struct CAN_message_t {
   uint32_t id; // can identifier
   uint8_t ext; // identifier is extended
+  uint8_t rtr; // remote transmission request packet type
   uint8_t len; // length of data
   uint16_t timeout; // milliseconds, zero will disable waiting
   uint8_t buf[8];

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Please add parts you are using successfully with Teensy 3.1 to this list.
 - NXP TJA1050T/VM,118 on the same 5V supply as the Teensy. (1MBPS)
 - Microchip MCP2551 on 5V (reported at 500KBPS)
 - Linear LT1796 on 5V (not speedtested)
+- Microchip MCP2562 with VIO on 3.3V (tested on Teensy 3.2 and 3.6)
 
 ###Driver API
 **FlexCAN(baud, id, txAlt, rxAlt)**


### PR DESCRIPTION
I have added the ability to read and write the RTR bit in the CAN messages as well as added the MCP2562 transceiver to the tested list as i have run it in a Teensy 3.2 and 3.6 at up to 1MBPS.